### PR TITLE
Fix for Rails 7.1 deprecation

### DIFF
--- a/lib/auditable/base.rb
+++ b/lib/auditable/base.rb
@@ -85,7 +85,13 @@ module Auditable
     # Returns user object
     #
     # Use same method name like in update_attributes:
-    alias_attribute :changed_by, :user
+    def changed_by = user
+    def changed_by?
+      user?
+    end
+    def changed_by=(v)
+      self.user = v
+    end
 
     def same_audited_content?(other_audit)
       other_audit and relevant_attributes == other_audit.relevant_attributes


### PR DESCRIPTION
```
DEPRECATION WARNING: Auditable::Base model aliases `user` and has a method called `user` defined. Starting in Rails 7.2 `changed_by` will not be calling `user` anymore. You may want to additionally define `changed_by` to preserve the current behavior. (called from tap at <internal:kernel>:90)
```